### PR TITLE
Fix a link to illumina support help page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1049,7 +1049,7 @@ This Partner Solution supports <code>f1.2xlarge</code>, <code>f1.4xlarge</code>,
 <p>The genomic input datasets that you want to run in the Partner Solution environment</p>
 </li>
 <li>
-<p>The DRAGEN-specific reference hash table directories that are provided by Illumina or that you create from FASTA files. For instructions on how to create reference hash table directories, refer to <a href="https://support.illumina.com/content/dam/illumina-support/help/Illumina_DRAGEN_Bio_IT_Platform_v3_7_1000000141465/Content/SW/Informatics/Dragen/GenerateReference_fDG_dtRef.htm/" target="_blank" rel="noopener">DRAGEN Bio-IT Platform User Guide</a></p>
+<p>The DRAGEN-specific reference hash table directories that are provided by Illumina or that you create from FASTA files. For instructions on how to create reference hash table directories, refer to <a href="https://support.illumina.com/content/dam/illumina-support/help/Illumina_DRAGEN_Bio_IT_Platform_v3_7_1000000141465/Content/SW/Informatics/Dragen/GenerateReference_fDG_dtRef.htm" target="_blank" rel="noopener">DRAGEN Bio-IT Platform User Guide</a></p>
 </li>
 <li>
 <p>An output folder for DRAGEN job outputs such as the binary alignment map (BAM) and variant call format (VCF) files</p>


### PR DESCRIPTION
The following href link `https://support.illumina.com/content/dam/illumina-support/help/Illumina_DRAGEN_Bio_IT_Platform_v3_7_1000000141465/Content/SW/Informatics/Dragen/GenerateReference_fDG_dtRef.htm/` on page https://aws-ia.github.io/cfn-ps-illumina-dragen/ is wrong.
