### PR TITLE
Update Lambda runtime to Python 3.12

### DIFF
--- a/templates/clean-bucket.template.yaml
+++ b/templates/clean-bucket.template.yaml
@@ -22,7 +22,7 @@ Resources:
     Properties:
       Description: Removes non-versioned files from an S3 Bucket.
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Role: !Ref ServiceToken
       Timeout: 240
       Code:

--- a/templates/clean-repository.template.yaml
+++ b/templates/clean-repository.template.yaml
@@ -22,7 +22,7 @@ Resources:
     Properties:
       Description: Removes an ECR Repository.
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Role: !Ref ServiceToken
       Timeout: 240
       Code:

--- a/templates/copy.template.yaml
+++ b/templates/copy.template.yaml
@@ -115,7 +115,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.12
       Role: !GetAtt CopyRole.Arn
       Timeout: 240
       Code:


### PR DESCRIPTION
Python 3.7 is deprecated since Dec 4, 2023, stack creation will fail using this runtime.

Update runtime to Python 3.12 to fix this issue.

Fixes: #37